### PR TITLE
Modernize Python and Django codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 
 # Django stuff:
 *.log
+secret.py
 
 # Sphinx documentation
 docs/_build/

--- a/bdlr/bdlr/settings/base.py
+++ b/bdlr/bdlr/settings/base.py
@@ -2,19 +2,17 @@
 Django settings for bdlr project.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.6/topics/settings/
+https://docs.djangoproject.com/en/4.2/topics/settings/
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.6/ref/settings/
+https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+from pathlib import Path
 
 from secret import *
-
-import appenlight_client.client as e_client
-APPENLIGHT = e_client.get_config({'appenlight.api_key': APPENLIGHT_PRIVATE_KEY})
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 ASSETS_DIR = os.path.join(BASE_DIR, "assets")
@@ -29,8 +27,6 @@ MAIN_CACHE_LENGTH = 60 * 60 * 24
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
-
-TEMPLATE_DEBUG = True
 
 ALLOWED_HOSTS = []
 
@@ -50,9 +46,8 @@ INSTALLED_APPS = (
     'flowers',
 )
 
-MIDDLEWARE_CLASSES = (
-    'appenlight_client.django_middleware.AppenlightMiddleware',
-
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
     'django.middleware.gzip.GZipMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -60,13 +55,29 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
     'waffle.middleware.WaffleMiddleware',
-)
+]
 
 ROOT_URLCONF = 'bdlr.urls'
 
 WSGI_APPLICATION = 'bdlr.wsgi.application'
+
+# Templates configuration
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
 
 # Database
@@ -100,4 +111,6 @@ STATICFILES_DIRS = (
     STATIC_DIR,
 )
 
-TEMPLATE_DIRS = (r"C:\work\bdlr\bdlr\bdlr\templates", )
+# Default primary key field type
+# https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/bdlr/bdlr/urls.py
+++ b/bdlr/bdlr/urls.py
@@ -1,19 +1,12 @@
 from django.conf import settings
-from django.conf.urls import patterns, include, url
+from django.contrib import admin
+from django.urls import re_path
 from django.conf.urls.static import static
 
-from django.contrib import admin
-admin.autodiscover()
+from flowers import views
 
-urlpatterns = patterns('',
-    # Examples:
-    # url(r'^blog/', include('blog.urls')),
-
-    url(r'^(?P<page>[0-9]*)$', 'flowers.views.index', name='index'),
-    url(r'api/test$', 'flowers.views.api_get_json', name='api_get_json'),
-
-    url(r"css/sprite_sheet_(\d+).css", 'flowers.views.generate_css', name="generate_css"),
-    url(r"api/json_chunk/(\d+)", 'flowers.views.json_chunk', name="json_chunk"),
-
-
-) + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+urlpatterns = [
+    re_path(r'^(?P<page>[0-9]*)$', views.index, name='index'),
+    re_path(r"css/sprite_sheet_(\d+).css", views.generate_css, name="generate_css"),
+    re_path(r"api/json_chunk/(\d+)", views.json_chunk, name="json_chunk"),
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/bdlr/bdlr/wsgi.py
+++ b/bdlr/bdlr/wsgi.py
@@ -4,7 +4,7 @@ WSGI config for bdlr project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
 """
 
 import os

--- a/bdlr/flowers/management/commands/scrap_poems.py
+++ b/bdlr/flowers/management/commands/scrap_poems.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         print_urls = self.get_print_urls()
         restart = False
         for index, url in enumerate(print_urls):
-            print index, "/", len(print_urls)
+            print(index, "/", len(print_urls))
             if "140" in url:
                 restart = True
 
@@ -36,11 +36,11 @@ class Command(BaseCommand):
         return [POEM_PRINT_URL % poem_id for poem_id in poem_ids]
 
     def handle_url(self, url):
-        print url
+        print(url)
         res = requests.get(url, headers=HEADERS)
         try:
             original_poem_name, english_canonical_name = re.findall("<h3>(.*) \((.+)\).*</h3>", res.text)[0]
-        except:
+        except (IndexError, ValueError):
             english_canonical_name = original_poem_name = re.findall("<h3>(.*) .*</h3>", res.text)[0]
 
         #Scrapping code looks so bad:
@@ -61,9 +61,9 @@ class Command(BaseCommand):
 
             try:
                 year = re.findall("(\d{4})", poem_meta_line)[0]
-            except:
+            except (IndexError, ValueError):
                 year = None
-            print year, author
+            print(year, author)
 
             if index == 0:
                 language, is_original = "French", True

--- a/bdlr/flowers/models.py
+++ b/bdlr/flowers/models.py
@@ -20,10 +20,10 @@ class PoemTranslation(BaseModel):
     author = models.CharField(max_length=100, null=True)
     meta_line = models.TextField(null=True)
 
-    poem = models.ForeignKey("Poem", null=True)
+    poem = models.ForeignKey("Poem", null=True, on_delete=models.CASCADE)
     importance = models.IntegerField(default=100)
 
-    def __unicode__(self):
+    def __str__(self):
         return "PoemTranslation %s by %s for poem %s" % (self.pk, self.author, self.poem.pk)
 
 
@@ -31,19 +31,19 @@ class Painting(BaseModel):
     image = models.ImageField(null=True, upload_to=settings.PAINTINGS_DIR)
     path = models.CharField(max_length=200, null=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return "Painting %s at %s." % (self.pk, self.path)
 
 
 class Poem(BaseModel):
     name = models.CharField(max_length=200)
-    original = models.ForeignKey(PoemTranslation, related_name="+")
+    original = models.ForeignKey(PoemTranslation, related_name="+", on_delete=models.CASCADE)
     translations = models.ManyToManyField(PoemTranslation, related_name="+")
     ordinal = models.IntegerField(null=True)
     image = models.ManyToManyField(Painting)
     link = models.URLField()
 
-    def __unicode__(self):
+    def __str__(self):
         return "Poem %s named %s at ordinal %s" % (self.pk, self.name, self.ordinal)
 
 

--- a/bdlr/flowers/tests.py
+++ b/bdlr/flowers/tests.py
@@ -1,9 +1,9 @@
 import os
+from unittest import mock
 
-import mock
 from django.test import TestCase
 
-import spritesheet_lib
+from flowers import spritesheet_lib
 
 
 IMAGE_DIR = os.path.join("assets", "paintings")
@@ -40,7 +40,6 @@ class SpriteSheetLibTest(TestCase):
     #         "4" : FOURTH_IMAGE,
     #     }
     #     css_txt = spritesheet_lib.create_sprite_css(name_to_image)
-    #     import pdb;pdb.set_trace()
 
     @mock.patch("PIL.Image.new")
     def test_cached_spritesheet(self, image_new_mock):
@@ -48,7 +47,6 @@ class SpriteSheetLibTest(TestCase):
         Test: Create sprite sheet whose image already exists on disk.
         Expected result: Sprite sheet wouldn't be recreated.
         """
-        import ipdb;ipdb.set_trace()
         spritesheet_lib.os.path.isfile = mock.MagicMock(return_value=True)
 
         name_to_image = {

--- a/bdlr/flowers/views.py
+++ b/bdlr/flowers/views.py
@@ -2,12 +2,12 @@ import json
 
 from django.conf import settings
 from django.http.response import HttpResponse
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_headers
 
-import models
-import spritesheet_lib
+from flowers import models
+from flowers import spritesheet_lib
 
 
 CHUNK_PAGES = [(1, 4),
@@ -57,7 +57,7 @@ def index(request, page=0):
 
     try:
         page = int(page)
-    except:
+    except (ValueError, TypeError):
         page = 0
 
     chunk = chunk_from_page(page)
@@ -70,7 +70,7 @@ def index(request, page=0):
          "page_count"   : page_count,
          "page_range"   : range(1, page_count)}
 
-    return render_to_response("mvp_note.html", dictionary=d)
+    return render(request, "mvp_note.html", d)
 
 
 #@cache_page(settings.MAIN_CACHE_LENGTH)
@@ -78,7 +78,7 @@ def generate_css(request, chunk_index):
     first_page, last_page = chunk_to_pages(int(chunk_index))
 
     name_to_image_path = {}
-    for i in xrange(first_page, last_page + 1):
+    for i in range(first_page, last_page + 1):
         poem = models.Poem.objects.get(ordinal=i)
         painting = poem.image.last()
         name_to_image_path["%s" % i] = painting.path

--- a/bdlr/templates/mvp_note.html
+++ b/bdlr/templates/mvp_note.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html>
     <head>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-django
-django-waffle
-django-extensions
+# Django and core dependencies
+Django>=4.2,<5.0
+django-waffle>=3.0.0
+django-extensions>=3.2.0
 
-pillow
-appenlight-client
+# Image processing
+Pillow>=10.0.0
 
-mock
+# Development/Testing (mock is now built into Python 3 as unittest.mock)


### PR DESCRIPTION
This comprehensive modernization updates the project from Django 1.6 (2013) to Django 4.2 LTS and ensures full Python 3 compatibility.

## Changes:

### Dependencies (requirements.txt)
- Upgraded Django from 1.6 to 4.2 LTS
- Updated django-waffle, django-extensions, and Pillow to modern versions
- Removed appenlight-client (outdated monitoring tool)
- Removed mock (now built into Python 3 as unittest.mock)

### Settings (bdlr/settings/base.py)
- Updated documentation links to Django 4.2
- Replaced MIDDLEWARE_CLASSES with MIDDLEWARE
- Removed deprecated TEMPLATE_DEBUG setting
- Added modern TEMPLATES configuration with proper context processors
- Fixed hardcoded Windows path for template directories
- Added DEFAULT_AUTO_FIELD for Django 3.2+ compatibility
- Removed appenlight middleware integration

### URL Configuration (bdlr/urls.py)
- Removed deprecated patterns() function
- Converted to list-based urlpatterns
- Changed from string-based view references to direct imports
- Replaced url() with re_path() for regex patterns
- Removed unnecessary admin.autodiscover() call
- Removed non-existent api_get_json endpoint

### Models (flowers/models.py)
- Replaced __unicode__() with __str__() for Python 3
- Added on_delete=models.CASCADE to all ForeignKey fields (required in Django 2.0+)

### Views (flowers/views.py)
- Changed from relative to absolute imports
- Replaced render_to_response() with render()
- Replaced xrange() with range() for Python 3
- Fixed bare except clauses with specific exception types

### Templates (templates/mvp_note.html)
- Replaced deprecated {% load staticfiles %} with {% load static %}

### Management Commands (flowers/management/commands/scrap_poems.py)
- Updated print statements to use print() function syntax
- Fixed bare except clauses with specific exception types

### Tests (flowers/tests.py)
- Changed from import mock to from unittest import mock
- Removed debug code (ipdb.set_trace())
- Changed to absolute imports

### Configuration (bdlr/wsgi.py, .gitignore)
- Updated documentation links to Django 4.2
- Added secret.py to .gitignore for security
- Created sample secret.py template

All changes have been tested with Django's system check (no issues found).